### PR TITLE
Layout-MatchDetailsVC-and-Router

### DIFF
--- a/CornholeScoreKeeper/CornholeScoreKeeper.xcodeproj/project.pbxproj
+++ b/CornholeScoreKeeper/CornholeScoreKeeper.xcodeproj/project.pbxproj
@@ -37,6 +37,10 @@
 		D2B3600E256DC97300C1C05B /* Record.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B3600D256DC97300C1C05B /* Record.swift */; };
 		D2B36014256DD2A800C1C05B /* RootTabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B36013256DD2A800C1C05B /* RootTabBarViewController.swift */; };
 		D2B36019256DD35300C1C05B /* NewMatchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B36018256DD35300C1C05B /* NewMatchViewController.swift */; };
+		D2B7EA17257EBE9D0095EECC /* MatchDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B7EA16257EBE9D0095EECC /* MatchDetailsViewController.swift */; };
+		D2B7EA1B257EBEB40095EECC /* MatchDetailsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B7EA1A257EBEB40095EECC /* MatchDetailsPresenter.swift */; };
+		D2B7EA1E257EBEC70095EECC /* MatchDetailsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B7EA1D257EBEC70095EECC /* MatchDetailsModel.swift */; };
+		D2B7EA21257EC0410095EECC /* MatchHistoryRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2B7EA20257EC0410095EECC /* MatchHistoryRouter.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -72,6 +76,10 @@
 		D2B3600D256DC97300C1C05B /* Record.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Record.swift; sourceTree = "<group>"; };
 		D2B36013256DD2A800C1C05B /* RootTabBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootTabBarViewController.swift; sourceTree = "<group>"; };
 		D2B36018256DD35300C1C05B /* NewMatchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewMatchViewController.swift; sourceTree = "<group>"; };
+		D2B7EA16257EBE9D0095EECC /* MatchDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchDetailsViewController.swift; sourceTree = "<group>"; };
+		D2B7EA1A257EBEB40095EECC /* MatchDetailsPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchDetailsPresenter.swift; sourceTree = "<group>"; };
+		D2B7EA1D257EBEC70095EECC /* MatchDetailsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchDetailsModel.swift; sourceTree = "<group>"; };
+		D2B7EA20257EC0410095EECC /* MatchHistoryRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchHistoryRouter.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -165,6 +173,7 @@
 				D2B35FEC256DBBB800C1C05B /* MatchHistoryViewController.swift */,
 				D2B35FEF256DBBDB00C1C05B /* MatchHistoryPresenter.swift */,
 				D2B35FF2256DBBEB00C1C05B /* MatchHistoryModel.swift */,
+				D2B7EA20257EC0410095EECC /* MatchHistoryRouter.swift */,
 			);
 			path = MatchHistory;
 			sourceTree = "<group>";
@@ -190,6 +199,7 @@
 				D2B36020256DD38400C1C05B /* PlayerStats */,
 				D2B36012256DD27C00C1C05B /* RootTabBarController */,
 				D2B35FEB256DBB9400C1C05B /* MatchHistory */,
+				D2B7EA15257EBE6E0095EECC /* MatchDetails */,
 				D2B36017256DD2C300C1C05B /* NewMatch */,
 				D2B34D4F2576F685008DDB3F /* CurrentMatch */,
 			);
@@ -233,6 +243,16 @@
 				D282FB262578257000C43E07 /* TurnIndicatorView.swift */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		D2B7EA15257EBE6E0095EECC /* MatchDetails */ = {
+			isa = PBXGroup;
+			children = (
+				D2B7EA16257EBE9D0095EECC /* MatchDetailsViewController.swift */,
+				D2B7EA1A257EBEB40095EECC /* MatchDetailsPresenter.swift */,
+				D2B7EA1D257EBEC70095EECC /* MatchDetailsModel.swift */,
+			);
+			path = MatchDetails;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -304,6 +324,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D2B7EA1E257EBEC70095EECC /* MatchDetailsModel.swift in Sources */,
 				D2B35FDD256DBB1A00C1C05B /* CornholeScoreKeeper.xcdatamodeld in Sources */,
 				D2B35FF0256DBBDB00C1C05B /* MatchHistoryPresenter.swift in Sources */,
 				D2B34D442576E8BF008DDB3F /* NewMatchRouter.swift in Sources */,
@@ -321,9 +342,12 @@
 				D2B35FD3256DBB1A00C1C05B /* AppDelegate.swift in Sources */,
 				D2B34D472576EA62008DDB3F /* NewMatchPresenter.swift in Sources */,
 				D2B35FFE256DC04C00C1C05B /* Player.swift in Sources */,
+				D2B7EA1B257EBEB40095EECC /* MatchDetailsPresenter.swift in Sources */,
+				D2B7EA21257EC0410095EECC /* MatchHistoryRouter.swift in Sources */,
 				D2B35FED256DBBB800C1C05B /* MatchHistoryViewController.swift in Sources */,
 				D2B3600E256DC97300C1C05B /* Record.swift in Sources */,
 				D267B93E256DE10200130192 /* TeamSelectView.swift in Sources */,
+				D2B7EA17257EBE9D0095EECC /* MatchDetailsViewController.swift in Sources */,
 				D285698D257999E100F43121 /* UIView+Extensions.swift in Sources */,
 				D2B35FD5256DBB1A00C1C05B /* SceneDelegate.swift in Sources */,
 				D2B36007256DC07000C1C05B /* Team.swift in Sources */,

--- a/CornholeScoreKeeper/CornholeScoreKeeper/Controllers/MatchDetails/MatchDetailsModel.swift
+++ b/CornholeScoreKeeper/CornholeScoreKeeper/Controllers/MatchDetails/MatchDetailsModel.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+protocol MatchDetailsModelType {
+
+}
+
+class MatchDetailsModel: MatchDetailsModelType {
+
+}

--- a/CornholeScoreKeeper/CornholeScoreKeeper/Controllers/MatchDetails/MatchDetailsPresenter.swift
+++ b/CornholeScoreKeeper/CornholeScoreKeeper/Controllers/MatchDetails/MatchDetailsPresenter.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+protocol MatchDetailsPresenterType {
+
+}
+
+protocol MatchDetailsViewType {
+
+}
+
+class MatchDetailsPresenter: MatchDetailsPresenterType {
+
+    var model: MatchDetailsModelType
+    var view: MatchDetailsViewType
+
+    init(model: MatchDetailsModelType, view: MatchDetailsViewType) {
+        self.model = model
+        self.view = view
+    }
+}

--- a/CornholeScoreKeeper/CornholeScoreKeeper/Controllers/MatchDetails/MatchDetailsViewController.swift
+++ b/CornholeScoreKeeper/CornholeScoreKeeper/Controllers/MatchDetails/MatchDetailsViewController.swift
@@ -1,10 +1,3 @@
-//
-//  MatchDetailsViewController.swift
-//  CornholeScoreKeeper
-//
-//  Created by Roberto Manese III on 12/7/20.
-//
-
 import UIKit
 
 class MatchDetailsViewController: UIViewController {

--- a/CornholeScoreKeeper/CornholeScoreKeeper/Controllers/MatchDetails/MatchDetailsViewController.swift
+++ b/CornholeScoreKeeper/CornholeScoreKeeper/Controllers/MatchDetails/MatchDetailsViewController.swift
@@ -1,0 +1,24 @@
+//
+//  MatchDetailsViewController.swift
+//  CornholeScoreKeeper
+//
+//  Created by Roberto Manese III on 12/7/20.
+//
+
+import UIKit
+
+class MatchDetailsViewController: UIViewController {
+
+    var presenter: MatchDetailsPresenterType!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .systemIndigo
+    }
+
+}
+
+extension MatchDetailsViewController: MatchDetailsViewType {
+    
+}

--- a/CornholeScoreKeeper/CornholeScoreKeeper/Controllers/MatchHistory/MatchHistoryRouter.swift
+++ b/CornholeScoreKeeper/CornholeScoreKeeper/Controllers/MatchHistory/MatchHistoryRouter.swift
@@ -1,0 +1,25 @@
+import UIKit
+
+protocol MatchHistoryRouterType {
+    var navigationController: UINavigationController { get set }
+    func toMatchDetailsViewController()
+}
+
+class MatchHistoryRouter: MatchHistoryRouterType {
+
+    var view: MatchHistoryViewController
+    var navigationController: UINavigationController
+
+    init(view: MatchHistoryViewController) {
+        self.view = view
+        self.navigationController = UINavigationController(rootViewController: view)
+    }
+
+    func toMatchDetailsViewController() {
+        let viewController = MatchDetailsViewController()
+        let model = MatchDetailsModel()
+        let presenter = MatchDetailsPresenter(model: model, view: viewController)
+        viewController.presenter = presenter
+        navigationController.pushViewController(viewController, animated: true)
+    }
+}

--- a/CornholeScoreKeeper/CornholeScoreKeeper/Controllers/MatchHistory/MatchHistoryViewController.swift
+++ b/CornholeScoreKeeper/CornholeScoreKeeper/Controllers/MatchHistory/MatchHistoryViewController.swift
@@ -5,6 +5,7 @@ class MatchHistoryViewController: UIViewController {
     private weak var tableView: UITableView!
 
     var presenter: MatchHistoryPresenter!
+    var router: MatchHistoryRouterType!
 
     override func loadView() {
         super.loadView()
@@ -52,7 +53,9 @@ class MatchHistoryViewController: UIViewController {
 }
 
 extension MatchHistoryViewController: UITableViewDelegate {
-
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        router.toMatchDetailsViewController()
+    }
 }
 
 extension MatchHistoryViewController: MatchHistoryViewType {

--- a/CornholeScoreKeeper/CornholeScoreKeeper/SceneDelegate.swift
+++ b/CornholeScoreKeeper/CornholeScoreKeeper/SceneDelegate.swift
@@ -12,34 +12,36 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let window = UIWindow(windowScene: windowScene)
 
         let matchHistoryVC: UINavigationController = {
-            let matchHistoryVC = MatchHistoryViewController()
-            let matchHistoryModel = MatchHistoryModel()
-            let matchHistoryPresenter = MatchHistoryPresenter(model: matchHistoryModel, view: matchHistoryVC)
-            matchHistoryVC.presenter = matchHistoryPresenter
-            matchHistoryVC.tabBarItem.title = "Match History"
-            matchHistoryVC.tabBarItem.image = UIImage(systemName: "list.bullet.rectangle")
-            let navigationController = UINavigationController(rootViewController: matchHistoryVC)
+            let viewController = MatchHistoryViewController()
+            let router = MatchHistoryRouter(view: viewController)
+            let navigationController = router.navigationController
+            let model = MatchHistoryModel()
+            let presenter = MatchHistoryPresenter(model: model, view: viewController)
+            viewController.router = router
+            viewController.presenter = presenter
+            viewController.tabBarItem.title = "Match History"
+            viewController.tabBarItem.image = UIImage(systemName: "list.bullet.rectangle")
             return navigationController
         }()
 
         let newMatchVC: UIViewController = {
-            let newMatchVC = NewMatchViewController()
-            let router = NewMatchRouter(view: newMatchVC)
+            let viewController = NewMatchViewController()
+            let router = NewMatchRouter(view: viewController)
             let navigationController = router.navigationController
             let model = NewMatchModel(players: Archive().players)
-            let presenter = NewMatchPresenter(model: model, view: newMatchVC)
-            newMatchVC.router = router
-            newMatchVC.presenter = presenter
-            navigationController.tabBarItem.title = "New Match"
-            navigationController.tabBarItem.image = UIImage(systemName: "plus.circle.fill")
+            let presenter = NewMatchPresenter(model: model, view: viewController)
+            viewController.router = router
+            viewController.presenter = presenter
+            viewController.tabBarItem.title = "New Match"
+            viewController.tabBarItem.image = UIImage(systemName: "plus.circle.fill")
             return navigationController
         }()
 
         let playerStatsVC: UIViewController = {
-            let playerStatsVC = PlayerStatsViewController()
-            playerStatsVC.tabBarItem.title = "Player Stats"
-            playerStatsVC.tabBarItem.image = UIImage(systemName: "chart.bar.xaxis")
-            return playerStatsVC
+            let viewController = PlayerStatsViewController()
+            viewController.tabBarItem.title = "Player Stats"
+            viewController.tabBarItem.image = UIImage(systemName: "chart.bar.xaxis")
+            return viewController
         }()
 
         let rootTabBarController = RootTabBarViewController()


### PR DESCRIPTION
Layout skeleton of MatchDetailVC, implement router logic to navigate to matchDetailVC, refactor sceneDelegate

* when user taps on matchResultsCell, app should navigate user to matchDetails Screen. User must be able to navigate back to matchHistoryVC.